### PR TITLE
ignore if folder exists, in case of container restart

### DIFF
--- a/deployment/console/console.yaml
+++ b/deployment/console/console.yaml
@@ -21,7 +21,7 @@ spec:
         - |-
           set -e;
           export MODULE_DIR=/app/console_config;
-          mkdir ${MODULE_DIR};
+          mkdir -p ${MODULE_DIR};
           echo "class K8sConfig:" >> ${MODULE_DIR}/__init__.py;
           echo "   API='${SERVICE}'" >> ${MODULE_DIR}/__init__.py;
         volumeMounts:


### PR DESCRIPTION
Fix to ignore if the MODULE_DIR folder already exists when creating it in the init container.

It is required because during a container restart, like for instance when the entire kubelet host reboots, the init containers are also restarted. 

See [init containers doc](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#:~:text=If%20the%20Pod%20restarts%2C%20or,init%20containers%20must%20execute%20again.)


_`Because init containers can be restarted, retried, or re-executed, init container code should be idempotent. In particular, code that writes to files on EmptyDirs should be prepared for the possibility that an output file already exists.`_
